### PR TITLE
Compile using  aligned_alloc() from Boost.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ $(foreach var,$(filter-out .% MAKE% SUFFIXES,$(.VARIABLES)),\
       $(eval $(var)=))))
 
 # Build options
-BUILTINS=1
-PRAGMA_FP_CONTRACT=0
-SIMD=1
-OPENMP=1
-DEBUG=0
-PROFILE=0
-SAVE_ASM=0
-WINDOWS=0
+BUILTINS?=1
+PRAGMA_FP_CONTRACT?=0
+SIMD?=1
+OPENMP?=1
+DEBUG?=0
+PROFILE?=0
+SAVE_ASM?=0
+WINDOWS?=0
 
 # VARIABLES
 CFLAGS+=-std=c11 -pedantic

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,15 @@ DEBUG?=0
 PROFILE?=0
 SAVE_ASM?=0
 WINDOWS?=0
+MACOS?=0
+BOOST?=0
 
 # VARIABLES
 CFLAGS+=-std=c11 -pedantic
 CFLAGS+=-msse2 -mfpmath=sse
 CFLAGS+=-g
+CXXFLAGS+=-msse2 -mfpmath=sse -std=c++17
+CXXFLAGS+=-g
 WARN_FLAGS+=-Wall -Wextra -Winline -Wshadow
 NO_WARN_FLAGS+=-w
 ifeq ($(CC),)
@@ -70,6 +74,19 @@ CFLAGS+=-mstackrealign # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48659
 RES+=icon.rc.o
 endif
 
+ifeq ($(MACOS),1)
+HOMEBREW:=$(shell brew --prefix)
+CPPFLAGS+=-I$(HOMEBREW)/include
+LDFLAGS+=-L$(HOMEBREW)/lib
+
+ifeq ($(BOOST),1)
+HOMEBREW_BOOST:=$(shell brew --prefix boost)
+CPPFLAGS+=-DBOOST_ALIGNED_ALLOC -I$(HOMEBREW_BOOST)/include
+LDFLAGS+=-L$(HOMEBREW_BOOST)/lib
+OBJS+=boost_aligned_alloc.o
+endif
+endif
+
 ifeq ($(SAVE_ASM),1)
 CFLAGS+=-save-temps -masm=intel -fverbose-asm
 endif
@@ -82,15 +99,22 @@ LDFLAGS+=$(BFLAGS)
 all: jpeg2png$(EXE)
 
 jpeg2png$(EXE): $(OBJS) $(RES) Makefile
+ifeq ($(BOOST),0)
 	$(CC) $(OBJS) $(RES) -o $@ $(LDFLAGS) $(LIBS)
+else
+	$(CXX) $(OBJS) $(RES) -o $@ $(CXXFLAGS) $(LDFLAGS) $(LIBS)
+endif
 
 -include $(OBJS:.o=.d)
 
 gopt/gopt.o: gopt/gopt.c gopt/gopt.h Makefile
-	$(CC) $< -c -o $@ $(CFLAGS) $(NO_WARN_FLAGS)
+	$(CC) $< -c -o $@ $(CFLAGS) $(CPPFLAGS) $(NO_WARN_FLAGS)
 
 %.o: %.c Makefile
-	$(CC) -MP -MMD $< -c -o $@ $(CFLAGS) $(WARN_FLAGS)
+	$(CC) -MP -MMD $< -c -o $@ $(CFLAGS) $(CPPFLAGS) $(WARN_FLAGS)
+
+%.o: %.cpp Makefile
+	$(CXX) -MP -MMD $< -c -o $@ $(CXXFLAGS) $(CPPFLAGS) $(WARN_FLAGS)
 
 %.rc.o: %.rc Makefile
 	$(WINDRES) $< $@

--- a/boost_aligned_alloc.cpp
+++ b/boost_aligned_alloc.cpp
@@ -1,0 +1,13 @@
+#include <boost/align.hpp>
+#include <boost/align/aligned_alloc.hpp>
+#include "utils.h"
+
+void *boost_aligned_alloc(size_t alignment, size_t size) {
+	return boost::alignment::aligned_alloc(alignment, size);
+}
+
+
+void boost_aligned_free(void *p) {
+	boost::alignment::aligned_free(p);
+}
+

--- a/utils.c
+++ b/utils.c
@@ -52,16 +52,16 @@ void stop_timer(clock_t t, const char *n) {
 }
 
 // compare image sized buffers, e.g. c and simd versions
-void compare(const char * name, unsigned w, unsigned h, float *new, float *old) {
+void compare(const char * name, unsigned w, unsigned h, float *bnew, float *bold) {
         const float epsilon = 1.e-6;
         for(unsigned y = 0; y < h; y++) {
                 for(unsigned x = 0; x < w; x++) {
-                        float new1 = *p(new, x, y, w, h);
-                        float old1 = *p(old, x, y, w, h);
-                        if(isnan(new1)) {
+                        float bnew1 = *p(bnew, x, y, w, h);
+                        float bold1 = *p(bold, x, y, w, h);
+                        if(isnan(bnew1)) {
                                 die("%u, %u is NaN", x, y);
-                        } else if (fabsf(new1 - old1) / old1 > epsilon) {
-                                die("difference at %s %u, %u: %.9e, %.9e\n", name, x, y, new1, old1);
+                        } else if (fabsf(bnew1 - bold1) / bold1 > epsilon) {
+                                die("difference at %s %u, %u: %.9e, %.9e\n", name, x, y, bnew1, bold1);
                         }
                 }
         }

--- a/utils.h
+++ b/utils.h
@@ -19,6 +19,11 @@ clock_t start_timer(const char *name);
 void stop_timer(clock_t t, const char *n);
 void compare(const char *name, unsigned w, unsigned h, float *bnew, float *bold);
 
+#ifdef BOOST_ALIGNED_ALLOC
+void *boost_aligned_alloc(size_t alignment, size_t size);
+void boost_aligned_free(void *p);
+#endif
+
 // Convenience macros
 #define MIN(a, b)  (((a) < (b)) ? (a) : (b))
 #define MAX(a, b)  (((a) > (b)) ? (a) : (b))
@@ -94,7 +99,11 @@ static inline void *alloc_simd(size_t n) {
 #if defined(_WIN32)
         void *p = _aligned_malloc(n, 16);
 #else
+#if defined BOOST_ALIGNED_ALLOC
+        void *p = boost_aligned_alloc(16, n);
+#else
         void *p = aligned_alloc(16, n);
+#endif
 #endif
         if(!p) { die("allocation error"); }
         ASSUME_ALIGNED(p);
@@ -105,7 +114,11 @@ static inline void free_simd(void *p) {
 #ifdef _WIN32
         _aligned_free(p);
 #else
+#if defined BOOST_ALIGNED_ALLOC
+        boost_aligned_free(p);
+#else
         free(p);
+#endif
 #endif
 }
 

--- a/utils.h
+++ b/utils.h
@@ -8,12 +8,16 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void die_message_start();
 noreturn void die(const char *msg, ...);
 noreturn void die_perror(const char *msg, ...);
 clock_t start_timer(const char *name);
 void stop_timer(clock_t t, const char *n);
-void compare(const char *name, unsigned w, unsigned h, float *new, float *old);
+void compare(const char *name, unsigned w, unsigned h, float *bnew, float *bold);
 
 // Convenience macros
 #define MIN(a, b)  (((a) < (b)) ? (a) : (b))
@@ -104,5 +108,9 @@ static inline void free_simd(void *p) {
         free(p);
 #endif
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Some minor modifications to compile when `aligned_alloc()` is not provided by the system libraries. A notable example of such systems are MacOS versions < 10.15.
To resolve this, we link against Boost's implementation of [aligned_alloc](https://www.boost.org/doc/libs/1_56_0/doc/html/align.html). A wrapper is used to link the Boost C++ library with the C code of jpeg2png. This behaviour is enabled by setting the `BOOST` build variable.

After this, jpeg2png can be compiled on MacOS < 10.15 using: `CC=clang CXX=clang++ MACOS=1 BOOST=1 OPENMP=0 make` (uses Boost `aligned_alloc`, and libjpeg from homebrew)

For MacOS >= 10.15, this should work: `CC=clang CXX=clang++ MACOS=1 OPENMP=0 make` (uses system's `aligned_alloc`, and libjpeg from homebrew)

