### PR TITLE
macos doesn't have aligned_alloc, so use the posix variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ EXE=.exe
 LDFLAGS+=-static -s
 CFLAGS+=-mstackrealign # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48659
 RES+=icon.rc.o
+else
+CFLAGS+=-D_POSIX_C_SOURCE=200112
 endif
 
 ifeq ($(SAVE_ASM),1)

--- a/utils.h
+++ b/utils.h
@@ -89,10 +89,13 @@ static inline float sqf(float x) {
 static inline void *alloc_simd(size_t n) {
 #if defined(_WIN32)
         void *p = _aligned_malloc(n, 16);
-#else
-        void *p = aligned_alloc(16, n);
-#endif
         if(!p) { die("allocation error"); }
+#else
+        void *p = NULL;
+        if (posix_memalign(&p, 16, n) != 0) {
+            die("aligned allocation error");
+        }
+#endif
         ASSUME_ALIGNED(p);
         return p;
 }


### PR DESCRIPTION
Solves same problem as https://github.com/victorvde/jpeg2png/pull/11 but without pulling in boost.

Haven't actually tested it since I don't have macos, but People On The Internet™ say that posix_memalign is available on macos.