### PR TITLE
Support GRAY & CMYK Jpegs, fix rounding bug

### DIFF
--- a/jpeg.c
+++ b/jpeg.c
@@ -46,6 +46,8 @@ void read_jpeg(FILE *in, struct jpeg *jpeg) {
                 memcpy(&(jpeg->coefs[c].quant_table), t->quantval, sizeof(uint16_t) * 64);
         }
 
+#define UPDIV(x,y) ((x + ((y) - 1)) / (y))
+
         jvirt_barray_ptr *coefs = jpeg_read_coefficients(&d);
         for(int c = 0; c < d.num_components; c++) {
                 jpeg_component_info *i = &d.comp_info[c];
@@ -56,10 +58,11 @@ void read_jpeg(FILE *in, struct jpeg *jpeg) {
                 coef->h = h;
                 coef->w_samp = d.max_h_samp_factor / i->h_samp_factor;
                 coef->h_samp = d.max_v_samp_factor / i->v_samp_factor;
-                if(coef->h / 8 != (jpeg->h / coef->h_samp + 7) / 8) {
+                if(coef->h / 8 != UPDIV(UPDIV(jpeg->h, coef->h_samp), 8)) {
                         die("jpeg invalid coef h size");
                 }
-                if(coef->w / 8 != (jpeg->w / coef->w_samp + 7) / 8) {
+                if(coef->w / 8 != UPDIV(UPDIV(jpeg->w, coef->w_samp), 8)) {
+                        printf("coeg->w = %d, jpeg->w = %d, coef->w_samp = %d\n", coef->w, jpeg->w, coef->w_samp);
                         die("jpeg invalid coef w size");
                 }
                 if(SIZE_MAX / coef->h / coef->w / coef->h_samp / coef->w_samp < 6) {

--- a/jpeg.c
+++ b/jpeg.c
@@ -31,7 +31,9 @@ void read_jpeg(FILE *in, struct jpeg *jpeg) {
         jpeg->h = d.image_height;
         jpeg->w = d.image_width;
 
-        if(d.num_components != 3) { die("only 3 component jpegs are supported"); }
+        jpeg->c = d.num_components;
+        if(d.num_components < 1 || d.num_components > 4)
+          { die("only 3 component jpegs are supported"); }
 
         for(int c = 0; c < d.num_components; c++) {
                 unsigned i = d.comp_info[c].quant_tbl_no;

--- a/jpeg.c
+++ b/jpeg.c
@@ -33,7 +33,7 @@ void read_jpeg(FILE *in, struct jpeg *jpeg) {
 
         jpeg->c = d.num_components;
         if(d.num_components < 1 || d.num_components > 4)
-          { die("only 3 component jpegs are supported"); }
+          { die("only jpegs with 1 to 4 components are supported (gray, rgb/yuv or cmyk)"); }
 
         for(int c = 0; c < d.num_components; c++) {
                 unsigned i = d.comp_info[c].quant_tbl_no;

--- a/jpeg.h
+++ b/jpeg.h
@@ -7,9 +7,10 @@
 #include "jpeg2png.h"
 
 struct jpeg {
+        unsigned c;
         unsigned h;
         unsigned w;
-        struct coef coefs[3];
+        struct coef coefs[4];
 };
 
 void read_jpeg(FILE *in, struct jpeg *jpeg);

--- a/png.c
+++ b/png.c
@@ -37,8 +37,8 @@ void write_png(FILE *out, unsigned w, unsigned h, unsigned bits, struct coef *y,
         for(unsigned i = 0; i < h; i++) {
                 for(unsigned j = 0; j < w; j++) {
                         float yi = *p(y->fdata, j, i, y->w, y->h);
-                        float cbi = *p(cb->fdata, j, i, cb->w, cb->h);
-                        float cri = *p(cr->fdata, j, i, cr->w, cr->h);
+                        float cbi = cb ? *p(cb->fdata, j, i, cb->w, cb->h) : 0.0;
+                        float cri = cr ? *p(cr->fdata, j, i, cr->w, cr->h) : 0.0;
 
                         // YCbCr -> RGB
                         float bitfactor = (1 << bits) / 256.;


### PR DESCRIPTION
First thanks for your work, this approach does wonders especially with texts.

I made a few improvements in my branch that you may be interested in:
- first I fixed a rounding bug with downsampled chroma (size as a number of block was not computed correctly when dimensions where not aligned modulo 8 and some planes were downsampled)
- then I added minimal (quick'n'dirty) support for gray files (single component) and CMYK files.

I think these are non standard, but I was given some produced by proprietary software (Adobe maybe), encoded as jpeg files with 4 independent components. Honestly I don't know enough about JPEG standard to know what to think of these. All I care is that `jpeg2png` worked reasonably well.